### PR TITLE
statically-linked, multi-arch, non-root, distroless image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
+ARG ARCH=amd64
+
 # Build stage
-FROM golang:alpine3.10 AS builder
+FROM golang:1.16-alpine3.13 AS builder
 WORKDIR /src
 ADD . /src
-RUN cd /src && go build -o elector cmd/leader-elector/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags='-s -w -extldflags "-static"' -o elector cmd/leader-elector/main.go
 
-FROM alpine:3.10.3
-RUN apk add --no-cache ca-certificates
+FROM gcr.io/distroless/static:nonroot-${ARCH}
+USER nonroot:nonroot
 WORKDIR /app
-COPY --from=builder /src/elector /app/
+COPY --from=builder --chown=nonroot:nonroot /src/elector /app/
 ENTRYPOINT ["./elector"]


### PR DESCRIPTION
Hi @kkosmrli, I have a couple of ideas on how to improve the size, security and portability of the Docker/container image we produce, so I tried them here and listed some steps and benefits we can get from them, let me know if you think it's reasonable. Thank you :)

This PR:
- it bumps the golang builder version to the latest available Go and Alpine
- it statically links the Go binary so then it can be used without a
  fully blown distro image (via extldflags). More on this [here](https://oddcode.daveamit.com/2018/08/16/statically-compile-golang-binary/)
- it strips the Go binary to reduce its size significantly (via ldflags).
  More on Go binary stripping [here](https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/).
  At the time of speaking this is the size improvement:
  ```
  32M 12 May 09:25 elector
  23M 12 May 09:25 elector-stripped
  ```
- it swaps the runner image from `alpine` to `distroless/static:nonroot`
  This image is similar to `scratch`
  (which has nothing in it) but adds `ca-certificates`, `tzdata`, `/tmp/`
  and a non user root (important to prevent privilege escalations and
  container evasions). More on distroless [here](https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md) and [here](https://hackernoon.com/distroless-containers-hype-or-true-value-2rfl3wat)
- it sets a Docker BUILD ARG which defaults to `amd64` but that can be
  overridden during docker build phase to build the image for different
  architectures (this could be automatically done by CI, if setup correctly),
  making this potentially compatible with arm architectures
  (i.e. Raspberry Pis, IOT setps, edge) and many more.