### PR TITLE
example: add RBAC

### DIFF
--- a/example/deployment.yaml
+++ b/example/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: election-example
 spec:
+  replicas: 2
   selector:
     matchLabels:
       app: election-example
@@ -11,6 +12,7 @@ spec:
       labels:
         app: election-example
     spec:
+      serviceAccountName: election-example
       containers:
       - name: test-container
         image: pstauffer/curl:v1.0.3
@@ -31,7 +33,7 @@ spec:
             memory: "64Mi"
             cpu: "100m"
       - name: elector-sidecar
-        image: kkosmrli/leader-elector:test
+        image: kkosmrli/leader-elector:release-0.1.1
         imagePullPolicy: Always
         resources:
           limits:
@@ -42,6 +44,5 @@ spec:
         args:
           - "--election=example-election"
           - "--namespace=default"
+          - "--locktype=configmaps"
           - "--port=4040"
-  replicas: 2 
-    

--- a/example/rbac.yaml
+++ b/example/rbac.yaml
@@ -1,0 +1,42 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: election-example
+  namespace: default
+rules:
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  verbs:
+  - get
+  - create
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: election-example
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: election-example
+roleRef:
+  kind: Role
+  name: election-example
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: election-example
+  namespace: default


### PR DESCRIPTION
- it adds Role Base Access Control (RBAC) resources needed by the `leader-elector` to run correctly. The Role specifies permissions for both `Configmaps`, `Leases` and `Endpoints`, allowing the example to work with whichever `locktype` the user picks
- it bumps the release in the example to the latest pinned release available 